### PR TITLE
Updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,59 @@
 This repo contains the files necessary to deploy a [Spark cluster](https://spark.apache.org/) on a basic [Kubernetes](https://kubernetes.io/) cluster.  This deployment will create 1 master node and any number of worker nodes.  Each node runs as a kubernetes pod.  This should work regardless of the kubernetes deployment.  It should work with any cloud provider or bare metal.
 
 ## Installation
+### Dependency Setup
+In order to deploy the clusters locally for testing, there are a few things that will need to be installed.  All steps in the section assume you are running on a Mac and have [Homebrew](https://brew.sh/) installed.
+
+Make sure that you have cask installed and up-to-date by running `brew tap homebrew/cask`.
+
+#### Install Docker
+[Docker](https://docs.docker.com/) is an open platform for developing, shipping, and running applications.  To get started, you will need to [Install Docker](https://docs.docker.com/docker-for-mac/install/) from the Docker website.
+
+#### Install Virtualbox
+[VirtualBox](https://www.virtualbox.org/wiki/Documentation) is open-source software for virtualizing the x86 computing architecture. It acts as a hypervisor, creating a VM (virtual machine) where the user can run another OS (operating system).
+
+To install it, run `brew install virtualbox`.
+
+This is the same as `brew install --cask virtualbox` and is a replacement for the old method of calling `brew cask install virtualbox`.
+
+Make sure that during install in `System Preferences > Security & Privacy > Allow` you checked the box for `Oracle`.  If it was not checked, check it, reinstall virtualbox using the steps above, and restart your computer.
+
+#### Install Kubectl
+[Kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) is a Kubernetes command-line tool that allows you to run [commands](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands) against Kubernetes clusters. You can use kubectl to deploy applications, inspect and manage cluster resources, and view logs.
+
+To install it run `brew install kubectl`.
+
+#### Install Minikube
+[Minikube](https://kubernetes.io/docs/tutorials/hello-minikube/) is a tool that lets you run Kubernetes locally.  It runs a single-node Kubernetes cluster on your personal computer (including Windows, macOS and Linux PCs) so that you can try out Kubernetes or for daily development work.  To work with it, you will also need virtualbox and kubectl so make sure to follow the installation steps above.
+
+To install it, run the following curl command:
+
+```
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.27.0/minikube-darwin-amd64 &&\
+  chmod +x minikube &&\
+  sudo mv minikube /usr/local/bin/
+```
+
+With minikube installed, you can start your minicube cluster with the `minikube start` command.  Hold tight, it might take a few minutes.
+
+Once the cluster is up and running, you should be able to confirm by executing the command `kubectl api-versions` to get a list of versions or `kubectl get pods --all-namespaces` to see all running pods and health state of the cluster.
+
+If you get an error that looks something like `Error starting host: Error getting state for host: machine does not exist` when running `minikube start` you can try to fix it by running:
+
+1. `minikube stop` to stop the cluster
+2. `minikube delete && rm -rf ~/.minikube && rm -rf ~/.kube` to delete the machine
+3. `minikube start` to re-run the cluster
+
+If you get an error that looks something like `Error starting host:  Error creating host: Error executing step: Creating VM.` you will want to make sure that virtualbox is installed correctly and that you have restarted your machine.
+
+If you are running the cluster locally, you may also need to install [hyperkit](https://minikube.sigs.k8s.io/docs/drivers/hyperkit/) with `brew install docker-machine-driver-hyperkit` and start minikube using the kit with `minikube start --vm-driver=hyperkit --bootstrapper=localkube`.
+
+#### Install Helm
+[Helm](https://helm.sh/docs/) helps you manage Kubernetes applications — Helm Charts help you define, install, and upgrade even the most complex Kubernetes application.
+
+To install it, run `brew install helm`.
+
+
 ### Deployment Values
 Deployment variables should be updated in the [values.yaml](charts/spark-cluster/values.yaml) file.
 
@@ -14,18 +67,18 @@ master:
     name: spark-base
     imageRepository: kringen
     image: spark-base
-    imageVersion: 3.8.0
+    imageVersion: 3.8.1
 ```
 The number of worker nodes is configured in the *worker* section.  The number of replicas controls how many worker nodes are created.
 ```bash
 worker:
   name: spark-worker
-  replicas: 5
+  replicas: 1
   container:
     name: spark-base
     imageRepository: kringen
     image: spark-base
-    imageVersion: 3.8.0
+    imageVersion: 3.8.1
 ```
 Resource limits are important to consider for worker nodes since Spark will not accept jobs if the correct resources (memory and CPU cores) are not available.
 
@@ -35,16 +88,28 @@ worker:
     resources:
       requests:
         memory: "1Gi"
-        cpu: "2"
+        cpu: "1"
       limits:
         memory: "2Gi"
         cpu: "3"
 ```
 ### Deployment Command
-The Spark cluster is deployed using the following command from the *kube-spark-cluster/charts* folder:
-```bash
-helm install spark-cluster ./spark-cluster
+The Spark cluster can now be deployed by:
+
+1. Navigating to the *kube-spark-cluster/charts* folder
+2. Running `helm install spark-cluster ./spark-cluster`
+
+You can test that this worked by running the command `kubectl get pods --namespace spark` and making sure the `spark-test` pod is present.
+
 ```
+NAME             READY   STATUS    RESTARTS   AGE
+spark-master-0   1/1     Running   0          11m
+spark-test       1/1     Running   0          20s
+spark-worker-0   1/1     Running   0          11m
+```
+
+If you have issues during installation, you can always start over by running `helm uninstall spark-cluster`.
+
 ## Cluster Dashboard
 Upon successful installation, the master node will be listening on port 8080.  This can be accessed by using kubectl port-forward comman and then opening the dashboard in a browser.
 ```bash

--- a/charts/spark-cluster/templates/namespace.yaml
+++ b/charts/spark-cluster/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}

--- a/charts/spark-cluster/templates/spark-master.yaml
+++ b/charts/spark-cluster/templates/spark-master.yaml
@@ -52,10 +52,10 @@ spec:
 {{- with .Values.master.container.ports }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-        volumeMounts:
-        - name: data-volume
-          mountPath: {{ .Values.master.container.dataVolumeMountPath }}
-      volumes:
-      - name: data-volume
-        persistentVolumeClaim:
-          claimName: {{ .Values.master.claimName }}
+        # volumeMounts:
+        # - name: data-volume
+        #   mountPath: {{ .Values.master.container.dataVolumeMountPath }}
+      # volumes:
+      # - name: data-volume
+      #   persistentVolumeClaim:
+      #     claimName: {{ .Values.master.claimName }}

--- a/charts/spark-cluster/templates/spark-worker.yaml
+++ b/charts/spark-cluster/templates/spark-worker.yaml
@@ -56,10 +56,10 @@ spec:
 {{- with .Values.worker.container.resources }}
 {{ toYaml . | indent 10 }}
 {{- end }}        
-        volumeMounts:
-        - name: data-volume
-          mountPath: {{ .Values.worker.container.dataVolumeMountPath }}
-      volumes:
-      - name: data-volume
-        persistentVolumeClaim:
-          claimName: {{ .Values.worker.claimName }}
+        # volumeMounts:
+        # - name: data-volume
+        #   mountPath: {{ .Values.worker.container.dataVolumeMountPath }}
+      # volumes:
+      # - name: data-volume
+      #   persistentVolumeClaim:
+      #     claimName: {{ .Values.worker.claimName }}

--- a/charts/spark-cluster/values.yaml
+++ b/charts/spark-cluster/values.yaml
@@ -34,7 +34,7 @@ master:
       name: frontend
     - containerPort: 7077
       name: service
-    dataVolumeMountPath: /srv/spark/data
+    # dataVolumeMountPath: /srv/spark/data
   service:
     ports:
     - port: 8080
@@ -44,7 +44,7 @@ master:
 
 worker:
   name: spark-worker
-  replicas: 5
+  replicas: 1
   container:
     name: spark-base
     imageRepository: kringen
@@ -76,14 +76,14 @@ worker:
     resources:
       requests:
         memory: "1Gi"
-        cpu: "2"
+        cpu: "1"
       limits:
         memory: "2Gi"
         cpu: "3"
     ports:
     - containerPort: 8081
       name: frontend
-    dataVolumeMountPath: /srv/spark/data
+    # dataVolumeMountPath: /srv/spark/data
   service:
     ports:
     - port: 8080


### PR DESCRIPTION
The documentation was updated to include details about dependencies required to run the helm chart.  In particular, it outlines how to install docker, virtualbox, kubectl, minikube, and helm with some troubleshooting items.  It also includes updates to:

* The YAML templates to make sure they run for anyone under this base configuration
* The code snippets under the Deployment Values section
* The Deployment Command section to add more details